### PR TITLE
AT - Add TidesQuery Service

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -25,7 +25,7 @@ public class TidesQueryService {
     }
 
     // Documentation for endpoint is at: https://api.tidesandcurrents.noaa.gov/api/prod/
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
-
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -9,7 +10,11 @@ import org.springframework.web.client.RestTemplate;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -28,6 +33,17 @@ public class TidesQueryService {
     public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
+        log.info("beginDate={}, endDate={}, station={}", beginDate, endDate, station);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of("beginDate", beginDate, "endDate", endDate, "station", station);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
         return "";
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -45,6 +45,6 @@ public class TidesQueryService {
 
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
                 uriVariables);
-        return "";
+        return re.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -19,9 +19,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
 
+@Slf4j
 @Service
 public class TidesQueryService {
 
+    ObjectMapper mapper = new ObjectMapper();
 
     private final RestTemplate restTemplate;
 
@@ -29,7 +31,6 @@ public class TidesQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    // Documentation for endpoint is at: https://api.tidesandcurrents.noaa.gov/api/prod/
     public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
@@ -1,0 +1,44 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(TidesQueryService.class)
+public class TidesQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private TidesQueryService tidesQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String beginDate = "10";
+        String endDate = "1.5";
+        String station = "34.4140"; // hard coded params for Storke Tower
+       
+        String expectedURL = TidesQueryService.ENDPOINT.replace("{beginDate}", beginDate)
+                .replace("{endDate}", endDate).replace("{station}", station);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = tidesQueryService.getJSON(beginDate, endDate, station);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add a service that wraps the Tides Query API from
https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date{endDate}&station{station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";

Closes #12 