### PR TITLE
Add location controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import edu.ucsb.cs156.spring.backenddemo.services.LocationQueryService;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +20,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 
 @Tag(name="Location info from nominatim.org")
+@Slf4j
 @RestController
 @RequestMapping("/api/locations")
 public class LocationController {
@@ -30,7 +32,10 @@ public class LocationController {
 
     @Operation(summary = "Get list of locations that match a given location name", description = "Uses API documented here: https://nominatim.org/release-docs/develop/api/Search/")
     @GetMapping("/get")
-    public ResponseEntity<String> getLocation(@Parameter(name="location", description="name to search", example="Isla Vista") @RequestParam String location) throws JsonProcessingException {
+    public ResponseEntity<String> getLocation(
+        @Parameter(name="location", description="name to search", example="Isla Vista") @RequestParam String location
+    ) throws JsonProcessingException {
+        log.info("getlocstion: location={}", location);
         String result = locationQueryService.getJSON(location);
         return ResponseEntity.ok().body(result);
     }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
@@ -1,8 +1,38 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
-import org.springframework.web.bind.annotation.RestController;
+import edu.ucsb.cs156.spring.backenddemo.services.LocationQueryService;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+
+@Tag(name="Locations from https://nominatim.openstreetmap.org")
 @RestController
+@RequestMapping("/api/locations")
 public class LocationController {
     
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    LocationQueryService locationQueryService;
+
+    @Operation(summary = "Get list of locations that match a given location name", description = "Uses API documented here: https://nominatim.org/release-docs/develop/api/Search/")
+    @GetMapping("/get")
+    public ResponseEntity<String> getLocation(@Parameter(name="location", description="name to search", example="Isla Vista") @RequestParam String location) throws JsonProcessingException {
+        String result = locationQueryService.getJSON(location);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 
 
-@Tag(name="Locations from https://nominatim.openstreetmap.org")
+@Tag(name="Location info from nominatim.org")
 @RestController
 @RequestMapping("/api/locations")
 public class LocationController {

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
@@ -16,7 +16,7 @@ public class LocationQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search/{location}?format=json";
 
     public String getJSON(String location) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.web.client.RestTemplate;
 
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -19,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
-@Slf4j
 @Service
 public class LocationQueryService {
     ObjectMapper mapper = new ObjectMapper();
@@ -33,12 +31,11 @@ public class LocationQueryService {
     public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search/{location}?format=json";
 
     public String getJSON(String location) throws HttpClientErrorException {
-        log.info("location={}", location);
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        HttpEntity<String> entity = new HttpEntity<>(headers);
+        HttpEntity<String> entity = new HttpEntity<>("bpdy", headers);
 
         Map<String, String> uriVariables = Map.of("location", location);
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
@@ -1,14 +1,28 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Slf4j
 @Service
 public class LocationQueryService {
+    ObjectMapper mapper = new ObjectMapper();
 
     private final RestTemplate restTemplate;
 
@@ -19,6 +33,16 @@ public class LocationQueryService {
     public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search/{location}?format=json";
 
     public String getJSON(String location) throws HttpClientErrorException {
-        return "";
+        log.info("location={}", location);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of("location", location);
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -18,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+@Slf4j
 @Service
 public class LocationQueryService {
     ObjectMapper mapper = new ObjectMapper();
@@ -28,14 +30,15 @@ public class LocationQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search/{location}?format=json";
+    public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search.php?q={location}&format=jsonv2";
 
     public String getJSON(String location) throws HttpClientErrorException {
+        log.info("location={}", location);
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        HttpEntity<String> entity = new HttpEntity<>("bpdy", headers);
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
         Map<String, String> uriVariables = Map.of("location", location);
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationControllerTests.java
@@ -42,7 +42,7 @@ public class LocationControllerTests {
   public void test_getLocation() throws Exception {
   
     String fakeJsonResult="{ \"fake\" : \"result\" }";
-    String location = "sacramento";
+    String location = "Denver";
     when(mockLocationQueryService.getJSON(eq(location))).thenReturn(fakeJsonResult);
 
     String url = String.format("/api/locations/get?location=%s",location);

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationControllerTests.java
@@ -1,0 +1,59 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.LocationQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = LocationController.class)
+public class LocationControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  LocationQueryService mockLocationQueryService;
+
+
+  @Test
+  public void test_getLocation() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String location = "sacramento";
+    when(mockLocationQueryService.getJSON(eq(location))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/locations/get?location=%s",location);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryServiceTests.java
@@ -19,13 +19,13 @@ public class LocationQueryServiceTests {
     private MockRestServiceServer mockRestServiceServer;
 
     @Autowired
-    private LocationQueryService locationQueryService;
+    private LocationQueryService LocationQueryService;
 
     @Test
     public void test_getJSON() {
 
-        String location = "Sacramento";
-        String expectedURL = locationQueryService.ENDPOINT.replace("{location}", location);
+        String location = "Denver";
+        String expectedURL = LocationQueryService.ENDPOINT.replace("{location}", location);
 
         String fakeJsonResult = "{ \"fake\" : \"result\" }";
 
@@ -34,7 +34,7 @@ public class LocationQueryServiceTests {
                 .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
                 .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
 
-        String actualResult = locationQueryService.getJSON(location);
+        String actualResult = LocationQueryService.getJSON(location);
         assertEquals(fakeJsonResult, actualResult);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryServiceTests.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(LocationQueryService.class)
+public class LocationQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private LocationQueryService locationQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String location = "Sacramento";
+        String expectedURL = locationQueryService.ENDPOINT.replace("{location}", location);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = locationQueryService.getJSON(location);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/location/get` that can be used to get information
about locations with a given name

http://team01-jtanggy-dev.dokku-01.cs.ucsb.edu/swagger-ui/index.html

closes #9